### PR TITLE
Fix for issue hoodie-server/issues/140

### DIFF
--- a/lib/account_manager.js
+++ b/lib/account_manager.js
@@ -3,7 +3,7 @@ var events = require('events'),
 
 
 exports.start = function (manager, callback) {
-    var am = {};   
+    var am = {};
 
     var ev = new events.EventEmitter();
     am.emit = function () {
@@ -13,7 +13,7 @@ exports.start = function (manager, callback) {
         ev.on.apply(ev, arguments);
     };
 
-    var user_db = manager._resolve('_users'); 
+    var user_db = manager._resolve('_users');
     var feed = couchr.changes(user_db, {include_docs: true});
 
     feed.on('change', function (change) {


### PR DESCRIPTION
fix for https://github.com/hoodiehq/hoodie-server/issues/140
which is itself caused by https://issues.apache.org/jira/browse/COUCHDB-1888

This may not be the right place for doing this, but it seemed logical given that it deals with account management, and the change event would receive empty documents otherwise.

Also, the list of fields is hard coded. I thought a dynamic approach to specifying the fields to make public was the right approach, but doing it without accidentally exposing secure information that a future plugin  might introduce to the user documents is going to be a tricky thing to do.
