### PR TITLE
less debug

### DIFF
--- a/lib/task_manager.js
+++ b/lib/task_manager.js
@@ -21,7 +21,6 @@ exports.start = function (manager, callback) {
         callback = callback || function (err) {
             if (err) {
                 console.error('Error adding source: ' + name);
-                console.error(err);
             }
         };
         function docChangeEvent(doc) {


### PR DESCRIPTION
`err` can be a really deep object totally plastering stdout, making other debugging hard.