### PR TITLE
renamed `ownerHash` to `hoodieId`

### DIFF
--- a/lib/account_manager.js
+++ b/lib/account_manager.js
@@ -30,14 +30,14 @@ exports.start = function (manager, callback) {
         });
         feed.once('stop', callback);
         feed.stop();
-    }; 
+    };
 
 
-    // CouchDB 1.4.0 has a introduced the requirement that user fields be explicitly declared public for them to be 
+    // CouchDB 1.4.0 has a introduced the requirement that user fields be explicitly declared public for them to be
     // returned. In the case of admins, this filtering should not be applied, but there's a bug.
     // BUG: https://issues.apache.org/jira/browse/COUCHDB-1888
-    var couchRoot = manager._resolve('');    
-    
+    var couchRoot = manager._resolve('');
+
     couchr.get(couchRoot, function(err, result) {
         if (err) {
             return callback(err, null);
@@ -47,8 +47,8 @@ exports.start = function (manager, callback) {
             var config_db = manager._resolve('_config');
 
             var publicFields = [
-                '_id', '_rev,name', 'password_sha', 'password_scheme', 'iterations', 
-                'name', 'roles', 'derived_key', 'salt', 'database', 'ownerHash', 
+                '_id', '_rev,name', 'password_sha', 'password_scheme', 'iterations',
+                'name', 'roles', 'derived_key', 'salt', 'database', 'hoodieId',
                 'updatedAt', 'signedUpAt', 'type'
             ];
 


### PR DESCRIPTION
Reason is that the new frontend method `hoodie.id()`,
that replaces `hoodie.account.ownerHash`.

To be merged together with https://github.com/hoodiehq/hoodie.js/pull/199
